### PR TITLE
added activerecord

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
-
+require File.expand_path('../spec/rails_app/config/application', __FILE__)
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+# YouApp::Application.load_tasks

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -2,12 +2,17 @@ class SsmConfig
   VERSION = '0.1.1'.freeze
   CONFIG_PATH = 'config'.freeze
   TABLE_NAME = 'ssm_config_records'.freeze
+  ACTIVE_RECORD_MODEL = 'SsmConfigRecord'.freeze
   class << self
     def method_missing(meth, *args, &block)
       config_file = Rails.root.join(CONFIG_PATH, "#{meth}.yml")
 
       if ActiveRecord::Base.connection.table_exists? TABLE_NAME
-        return {}
+        if ACTIVE_RECORD_MODEL.constantize.exists?(:file => meth.to_s)
+          return {}
+        else
+          super
+        end
       elsif File.exist?(config_file)
         write_config_accessor_for(meth)
         send(meth)

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -1,16 +1,16 @@
 class SsmConfig
   VERSION = '0.1.1'.freeze
   CONFIG_PATH = 'config'.freeze
-
+  TABLE_NAME = 'ssm_config_records'.freeze
   class << self
-    def method_missing(meth, *args, &block)
+    def method_missing(meth, *_args)
       config_file = Rails.root.join(CONFIG_PATH, "#{meth}.yml")
 
-      if File.exist?(config_file)
+      if ActiveRecord::Base.connection.table_exists? TABLE_NAME
+        return true
+      elsif File.exist?(config_file)
         write_config_accessor_for(meth)
         send(meth)
-      else
-        super
       end
     end
 

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -8,7 +8,7 @@ class SsmConfig
       config_file = Rails.root.join(CONFIG_PATH, "#{meth}.yml")
 
       if ActiveRecord::Base.connection.table_exists? TABLE_NAME
-        if ACTIVE_RECORD_MODEL.constantize.exists?(:file => meth.to_s)
+        if defined? ACTIVE_RECORD_MODEL.constantize and ACTIVE_RECORD_MODEL.constantize.exists?(:file => meth.to_s)
           return {}
         else
           super

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -3,14 +3,16 @@ class SsmConfig
   CONFIG_PATH = 'config'.freeze
   TABLE_NAME = 'ssm_config_records'.freeze
   class << self
-    def method_missing(meth, *_args)
+    def method_missing(meth, *args, &block)
       config_file = Rails.root.join(CONFIG_PATH, "#{meth}.yml")
 
       if ActiveRecord::Base.connection.table_exists? TABLE_NAME
-        return true
+        return {}
       elsif File.exist?(config_file)
         write_config_accessor_for(meth)
         send(meth)
+      else
+        super
       end
     end
 

--- a/spec/rails_app/bin/rails
+++ b/spec/rails_app/bin/rails
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+APP_PATH = File.expand_path('../config/application', __dir__)
+# require_relative '../config/boot'
+require 'rails/commands'

--- a/spec/rails_app/config/application.rb
+++ b/spec/rails_app/config/application.rb
@@ -1,4 +1,5 @@
 require 'active_record/railtie'
+require 'rails/all'
 
 module RailsApp
   class Application < Rails::Application

--- a/spec/rails_app/config/database.yml
+++ b/spec/rails_app/config/database.yml
@@ -1,26 +1,8 @@
-sqlite3mem: &SQLITE3MEM
+development:
   adapter: sqlite3
   database: ":memory:"
-
-sqlite3: &SQLITE
-  adapter: sqlite3
-  database: audited_test.sqlite3.db
-
-postgresql: &POSTGRES
-  adapter: postgresql
-  username: postgres
-  password: postgres
-  host: localhost
-  database: audited_test
-  min_messages: ERROR
-
-mysql: &MYSQL
-  adapter: mysql2
-  host: localhost
-  username: root
-  password: root
-  database: audited_test
-  charset: utf8
+  
 
 test:
-  <<: *<%= ENV['DB'] || 'SQLITE3MEM' %>
+  adapter: sqlite3
+  database: ":memory:"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,14 @@
 require 'bundler/setup'
 require 'ssm_config'
 require 'byebug'
+require 'ssm_config_spec_helpers'
+require 'support/active_record/models'
+
+SPEC_ROOT = Pathname.new(File.expand_path('../', __FILE__))
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-
+  config.include SsmConfigSpecHelpers
   config.example_status_persistence_file_path = '.rspec_status'
 
   config.expect_with :rspec do |c|

--- a/spec/ssm_config_activerecord_spec.rb
+++ b/spec/ssm_config_activerecord_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+class SsmConfigDummy < ::ActiveRecord::Base
+  self.table_name = 'ssm_config_records'
+end
+
+RSpec.describe SsmConfig do
+  before do
+    stub_const('SsmConfig::CONFIG_PATH', '../fixtures')
+    run_migrations(:up, migrations_path, 1)
+  end
+
+  let(:migrations_path) { SPEC_ROOT.join('support/active_record/postgres') }
+
+  after do
+    run_migrations(:down, migrations_path)
+  end
+
+  context 'when table exists' do
+    it 'returns true' do
+      expect(described_class.test).to eq(true)
+    end
+  end
+end

--- a/spec/ssm_config_activerecord_spec.rb
+++ b/spec/ssm_config_activerecord_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SsmConfig do
 
   context 'when table exists' do
     it 'returns true' do
-      expect(described_class.test).to eq(true)
+      expect(described_class.test).to eq({})
     end
   end
 end

--- a/spec/ssm_config_activerecord_spec.rb
+++ b/spec/ssm_config_activerecord_spec.rb
@@ -9,18 +9,29 @@ end
 RSpec.describe SsmConfig do
   before do
     stub_const('SsmConfig::CONFIG_PATH', '../fixtures')
+    stub_const('SsmConfig::ACTIVE_RECORD_MODEL', 'SsmConfigDummy')
     run_migrations(:up, migrations_path, 1)
   end
 
   let(:migrations_path) { SPEC_ROOT.join('support/active_record/postgres') }
+  let(:error_message) { "undefined method `non_existent' for SsmConfig:Class" }
 
   after do
     run_migrations(:down, migrations_path)
   end
 
   context 'when table exists' do
-    it 'returns true' do
-      expect(described_class.test).to eq({})
+    context 'when file exists' do
+      it 'returns empty' do
+        SsmConfigDummy.new(:file => 'test', :accessor_keys => 'foo', :value => 'bar').save
+        expect(described_class.test).to eq({})
+      end
+    end
+
+    context 'when file doesn\'t exist' do
+      it 'file doesn\'t exist' do
+        expect { described_class.non_existent }.to raise_error(NoMethodError).with_message(error_message)
+      end
     end
   end
 end

--- a/spec/ssm_config_spec_helpers.rb
+++ b/spec/ssm_config_spec_helpers.rb
@@ -1,0 +1,15 @@
+module SsmConfigSpecHelpers
+  def run_migrations(direction, migrations_paths, target_version = nil)
+    if rails_below?('5.2.0.rc1')
+      ActiveRecord::Migrator.send(direction, migrations_paths, target_version)
+    elsif rails_below?('6.0.0.rc1')
+      ActiveRecord::MigrationContext.new(migrations_paths).send(direction, target_version)
+    else
+      ActiveRecord::MigrationContext.new(migrations_paths, ActiveRecord::SchemaMigration).send(direction, target_version)
+    end
+  end
+
+  def rails_below?(rails_version)
+    Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new(rails_version)
+  end
+end

--- a/spec/support/active_record/models.rb
+++ b/spec/support/active_record/models.rb
@@ -1,0 +1,9 @@
+require 'cgi'
+require File.expand_path('../schema', __FILE__)
+
+module Models
+  module ActiveRecord
+    class SsmConfigRecord < ::ActiveRecord::Base
+    end
+  end
+end

--- a/spec/support/active_record/postgres/1_create_records.rb
+++ b/spec/support/active_record/postgres/1_create_records.rb
@@ -1,0 +1,13 @@
+class CreateRecords < ActiveRecord::Migration[5.0]
+  def self.up
+    create_table :ssm_config_records do |t|
+      t.column :file, :string
+      t.column :accessor_keys, :string
+      t.column :value, :string
+    end
+  end
+
+  def self.down
+    drop_table :ssm_config_records
+  end
+end

--- a/spec/support/active_record/schema.rb
+++ b/spec/support/active_record/schema.rb
@@ -1,0 +1,46 @@
+require 'active_record'
+require 'logger'
+
+begin
+  if ActiveRecord.version >= Gem::Version.new('6.1.0')
+    db_config = ActiveRecord::Base.configurations.configs_for(:env_name => Rails.env).first
+    ActiveRecord::Tasks::DatabaseTasks.create(db_config)
+  else
+    db_config = ActiveRecord::Base.configurations[Rails.env].clone
+    db_type = db_config['adapter']
+    db_name = db_config.delete('database')
+    raise StandardError, 'No database name specified.' if db_name.blank?
+    if db_type == 'sqlite3'
+      db_file = Pathname.new(__FILE__).dirname.join(db_name)
+      db_file.unlink if db_file.file?
+    else
+      if defined?(JRUBY_VERSION)
+        db_config.symbolize_keys!
+        db_config[:configure_connection] = false
+      end
+      adapter = ActiveRecord::Base.send("#{db_type}_connection", db_config)
+      adapter.recreate_database db_name, db_config.slice('charset').symbolize_keys
+      adapter.disconnect!
+    end
+  end
+rescue StandardError => e
+  Kernel.warn e
+end
+
+logfile = Pathname.new(__FILE__).dirname.join('debug.log')
+logfile.unlink if logfile.file?
+ActiveRecord::Base.verbose_query_logs = true
+
+ActiveRecord::Base.logger = Logger.new(logfile)
+
+ActiveRecord::Migration.verbose = false
+
+ActiveRecord::Base.establish_connection(YAML.safe_load(File.read('./spec/rails_app/config/database.yml'))['test'])
+
+ActiveRecord::Schema.define do
+  create_table :ssm_config_records do |t|
+    t.column :file, :string
+    t.column :accessor_keys, :string
+    t.column :value, :string
+  end
+end


### PR DESCRIPTION
Closes: https://snapsheettech.atlassian.net/browse/SNAPTX-3836

Added boilerplate for ActiveRecord to be compatible with the gem

`SsmConfig` now checks if the table `ssm_config_records` exists and returns true if it does. Otherwise, it defaults to the original gem behavior.

Spec for this behavior added in `ssm_config_activerecord_spec.rb`

Mostly just set up for a later commit which will extend gem functionality