### PR TITLE
Patch Casing Edge Case

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,19 @@ This search will be exclusive: i.e., if any row exists in the table then the gem
 
 To migrate a YAML file in the `config` directory into `SsmConfigRecord`, the class `SsmConfig::MigrationHelper` can be used. `MigrationHelper` takes in the file name, and has `up` and `down` methods.
 
-The `up` method will migrate the file into the table: if any validations are violated, then all rows that were added in the current call will be deleted, returning the table to the initial state.
+The `up` method will migrate the file into the table: if any validations are violated, then all rows that were added in the current call will be deleted, returning the table to the initial state. The following is a custom validation for datatype (which can be added in the corresponding model file):
+
+```ruby
+class SsmConfigRecord < ApplicationRecord
+  validate :datatype_support
+
+  def datatype_support
+    possible_types = ['s', 'i', 'b', 'f']
+    errors.add(:datatype, "is not a valid datatype (#{datatype})") unless possible_types.include? datatype.downcase[0]
+  end
+end
+```
+
 
 The `down` method will remove _all_ rows in the table that match the file name. A sample migration is as follows:
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ class SsmConfigRecord < ApplicationRecord
   validate :datatype_support
 
   def datatype_support
-    possible_types = ['s', 'i', 'b', 'f']
-    errors.add(:datatype, "is not a valid datatype (#{datatype})") unless possible_types.include? datatype.downcase[0]
+    errors.add(:datatype, "is not a valid datatype (#{datatype})") unless SsmConfig::SsmStorage::Db::VALID_DATATYPES.include? datatype.downcase[0]
   end
 end
 ```

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/time'
 
 module SsmConfig
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -1,13 +1,13 @@
-require './lib/ssm_config/ssm_storage/db.rb'
-require './lib/ssm_config/ssm_storage/yml.rb'
-require './lib/ssm_config/ssm_storage/empty.rb'
-require './lib/ssm_config/errors.rb'
-require './lib/ssm_config/migration_helper.rb'
+require 'ssm_config/ssm_storage/db.rb'
+require 'ssm_config/ssm_storage/yml.rb'
+require 'ssm_config/ssm_storage/empty.rb'
+require 'ssm_config/errors.rb'
+require 'ssm_config/migration_helper.rb'
 require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/time'
 
 module SsmConfig
-  VERSION = '1.2.0'.freeze
+  VERSION = '1.2.1'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -41,8 +41,9 @@ module SsmConfig
       end
 
       def transform_class(value, type)
-        raise SsmConfig::UnsupportedDatatype, 'Not a valid class: must be one of string, integer, boolean, or float' unless VALID_DATATYPES.include? type.to_s.downcase[0]
-        return value.send("to_#{type.to_s.downcase[0]}") unless type[0] == 'b'
+        type_char = type.to_s.downcase[0]
+        raise SsmConfig::UnsupportedDatatype, 'Not a valid class: must be one of string, integer, boolean, or float' unless VALID_DATATYPES.include? type_char
+        return value.send("to_#{type_char}") unless type_char == 'b'
         convert_boolean(value)
       end
 

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -3,6 +3,7 @@ module SsmConfig
     class Db
       TABLE_NAME = 'ssm_config_records'.freeze
       ACTIVE_RECORD_MODEL = 'SsmConfigRecord'.freeze
+      VALID_DATATYPES = ['s', 'i', 'b', 'f'].freeze
       def initialize(file_name)
         @file_name = file_name
       end
@@ -40,8 +41,7 @@ module SsmConfig
       end
 
       def transform_class(value, type)
-        possible_types = ['s', 'i', 'b', 'f']
-        raise SsmConfig::UnsupportedDatatype, 'Not a valid class: must be one of string, integer, boolean, or float' unless possible_types.include? type.to_s.downcase[0]
+        raise SsmConfig::UnsupportedDatatype, 'Not a valid class: must be one of string, integer, boolean, or float' unless VALID_DATATYPES.include? type.to_s.downcase[0]
         return value.send("to_#{type.to_s.downcase[0]}") unless type[0] == 'b'
         convert_boolean(value)
       end

--- a/spec/lib/ssm_config/migration_helper_spec.rb
+++ b/spec/lib/ssm_config/migration_helper_spec.rb
@@ -41,9 +41,7 @@ RSpec.describe 'SsmStorage::MigrationHelper' do
       it 'returns table to original state' do
         migration_helper.up
         allow(SsmConfigDummy).to receive(:create!).and_raise.and_return(ActiveRecord::RecordInvalid)
-        expect { migration_helper.up }
-          .to raise_error { ActiveRecord::RecordInvalid }
-          .and change { SsmConfigDummy.where(:file => 'data').size }.by(0)
+        expect { migration_helper.up }.to change { SsmConfigDummy.where(:file => 'data').size }.by(0)
       end
     end
   end

--- a/spec/lib/ssm_config/ssm_storage/db_spec.rb
+++ b/spec/lib/ssm_config/ssm_storage/db_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe 'SsmStorage::Db' do
 
     context 'when datatype is boolean' do
       it 'returns boolean' do
-        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:value => 'true')
-        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'boolean')
+        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:value => 'True')
+        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'Boolean')
         expect(db_query.hash[:test][0]).to eq(true)
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe 'SsmStorage::Db' do
     context 'when boolean is invalid' do
       it 'raises error' do
         SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:value => 'invalid boolean')
-        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'boolean')
+        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'Boolean')
         expect { db_query.hash[:test][0] }.to raise_error(SsmConfig::InvalidBoolean).with_message(invalid_boolean_message)
       end
     end


### PR DESCRIPTION
There was a small edge case where if `datatype` for boolean was uppercase, then it wouldn't process it properly.

Fixed by ensuring `.downcase` logic is applied in this case.

Updated specs to also check for this.