### PR TITLE
Patch Boolean edge case

### DIFF
--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/time'
 
 module SsmConfig
-  VERSION = '1.2.1'.freeze
+  VERSION = '1.2.2'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -41,8 +41,9 @@ module SsmConfig
       end
 
       def transform_class(value, type)
-        raise SsmConfig::UnsupportedDatatype, 'Not a valid class: must be one of string, integer, boolean, or float' unless VALID_DATATYPES.include? type.to_s.downcase[0]
-        return value.send("to_#{type.to_s.downcase[0]}") unless type[0] == 'b'
+        type_char = type.to_s.downcase[0]
+        raise SsmConfig::UnsupportedDatatype, 'Not a valid class: must be one of string, integer, boolean, or float' unless VALID_DATATYPES.include? type_char
+        return value.send("to_#{type_char}") unless type_char == 'b'
         convert_boolean(value)
       end
 

--- a/spec/lib/ssm_config/ssm_storage/db_spec.rb
+++ b/spec/lib/ssm_config/ssm_storage/db_spec.rb
@@ -81,8 +81,8 @@ RSpec.describe 'SsmStorage::Db' do
 
     context 'when datatype is boolean' do
       it 'returns boolean' do
-        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:value => 'true')
-        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'boolean')
+        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:value => 'True')
+        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'Boolean')
         expect(db_query.hash[:test][0]).to eq(true)
       end
     end
@@ -90,7 +90,7 @@ RSpec.describe 'SsmStorage::Db' do
     context 'when boolean is invalid' do
       it 'raises error' do
         SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:value => 'invalid boolean')
-        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'boolean')
+        SsmConfigDummy.find_by(:file => 'data', :accessor_keys => 'test,[0]').update(:datatype => 'Boolean')
         expect { db_query.hash[:test][0] }.to raise_error(SsmConfig::InvalidBoolean).with_message(invalid_boolean_message)
       end
     end


### PR DESCRIPTION
There was a small edge case where if `datatype` for boolean was uppercase, then it wouldn't process it properly.

Fixed by ensuring `.downcase` logic is applied in this case.

Updated specs to also check for this.