### PR TITLE
Add No Database Rescue

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Or install it yourself as:
 
 To utilize ActiveRecords, create the following model:
 ```
-rails generate model SsmConfigRecord file:string:index accessor_keys:string value:string datatype:string
+rails generate model SsmConfigRecord file:string:index accessor_keys:string value:text datatype:string
 ```
 
 The supported datatypes are `[string, integer, boolean, float]`. The first character entered in the field `datatype` should be the character that corresponds to the first character of the datatype (so one of `[s, i, b, f]`). This field is not case-sensitive. 

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -7,7 +7,7 @@ require 'active_support/core_ext/hash/indifferent_access'
 require 'active_support/time'
 
 module SsmConfig
-  VERSION = '1.2.2'.freeze
+  VERSION = '1.2.3'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -12,7 +12,6 @@ module SsmConfig
         return active_record_model_exists? if active_record_exists? && constant_exists?
         false
         rescue ActiveRecord::NoDatabaseError
-          puts("hello")
           return false
       end
 

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -11,8 +11,8 @@ module SsmConfig
       def table_exists?
         return active_record_model_exists? if active_record_exists? && constant_exists?
         false
-        rescue ActiveRecord::NoDatabaseError
-          return false
+      rescue ActiveRecord::NoDatabaseError
+        return false
       end
 
       def hash

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -11,6 +11,9 @@ module SsmConfig
       def table_exists?
         return active_record_model_exists? if active_record_exists? && constant_exists?
         false
+        rescue ActiveRecord::NoDatabaseError
+          puts("hello")
+          return false
       end
 
       def hash

--- a/spec/lib/ssm_config/ssm_storage/db_spec.rb
+++ b/spec/lib/ssm_config/ssm_storage/db_spec.rb
@@ -24,6 +24,13 @@ RSpec.describe 'SsmStorage::Db' do
   end
 
   describe '#table_exists?' do
+    context 'when database doesn\'t exist' do
+      it 'returns false' do
+        query = SsmConfig::SsmStorage::Db.new('non_existent')
+        allow(ActiveRecord::Base.connection).to receive(:table_exists?).and_raise.and_return(ActiveRecord::NoDatabaseError)
+        expect(query.table_exists?).to eq(false)
+      end
+    end
     context 'when file doesn\'t exist' do
       it 'table_exists? returns false' do
         query = SsmConfig::SsmStorage::Db.new('non_existent')

--- a/spec/lib/ssm_config/ssm_storage/db_spec.rb
+++ b/spec/lib/ssm_config/ssm_storage/db_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe 'SsmStorage::Db' do
         expect(query.table_exists?).to eq(false)
       end
     end
+
     context 'when file doesn\'t exist' do
       it 'table_exists? returns false' do
         query = SsmConfig::SsmStorage::Db.new('non_existent')


### PR DESCRIPTION
In the case of no database, added in a rescue to bypass the checks for `SsmConfig::SsmStorage::Db``. 

Added spec.

Updated readme so that value field is `text`