### PR TITLE
SNAPTX-4358 [SsmConfig] Gem Inconsistent Behavior for Values which exists in File as well as DB

### DIFF
--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -6,7 +6,7 @@ require 'ssm_config/migration_helper.rb'
 require 'active_support/all'
 
 module SsmConfig
-  VERSION = '1.3.4'.freeze
+  VERSION = '1.3.5'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -16,7 +16,7 @@ module SsmConfig
       end
 
       def db_connected?
-        ActiveRecord::Base.connected?
+        ActiveRecord::Base.connection.exists?
       end
 
       def hash

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -16,7 +16,7 @@ module SsmConfig
       end
 
       def db_connected?
-        ActiveRecord::Base.connection.exists?
+        ActiveRecord::Base.connection.active?
       end
 
       def hash


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SNAPTX-4358
## What
Remove ActiveRecord Database connection check
Instead of
ActiveRecord::Base.connected?
use
ActiveRecord::Base.connection.active?

## Why
We need make DB call consistent and not relying on the consumer to call the DB.


## Describe changes

## Testing

- Without making an db query in rails console. the gem always returns yaml fallback.. but if you do db query then the gem returns the db record.

- Every DB record would be returned first and then the yaml fallback.

