### PR TITLE
Change Allowed Push Host For publishing repo to github

### DIFF
--- a/ssm_config.gemspec
+++ b/ssm_config.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.license       = 'MIT'
 
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = 'https://rubygems.org'
+    spec.metadata['github_repo'] = 'https://github.com/bodyshopbidsdotcom/ssm_config'
+    spec.metadata['allowed_push_host'] = 'https://rubygems.pkg.github.com/bodyshopbidsdotcom'
   else
     raise 'RubyGems 2.0 or newer is required to protect against ' \
       'public gem pushes.'


### PR DESCRIPTION

## What
- Changed the allowed push host on gem

## Why
- For releasing version `0.3.5`
- This allow us to publish gem in internal repository as per @santi-h suggestion.