### PR TITLE
Psych 4.0 - Allow aliases for YAML load

### DIFF
--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -6,7 +6,7 @@ require 'ssm_config/migration_helper.rb'
 require 'active_support/all'
 
 module SsmConfig
-  VERSION = '1.3.6'.freeze
+  VERSION = '1.4.0'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -6,7 +6,7 @@ require 'ssm_config/migration_helper.rb'
 require 'active_support/all'
 
 module SsmConfig
-  VERSION = '1.3.5'.freeze
+  VERSION = '1.3.6'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config/migration_helper.rb
+++ b/lib/ssm_config/migration_helper.rb
@@ -64,7 +64,11 @@ module SsmConfig
     end
 
     def hash
-      yaml_loaded = YAML.load(File.read((file_path).to_s))
+      yaml_loaded = if Psych::VERSION > '4.0'
+        YAML.safe_load(File.read((file_path).to_s), aliases: true)
+      else
+        YAML.load(File.read((file_path).to_s))
+      end
       (yaml_loaded[Rails.env] || yaml_loaded['any']).try(:with_indifferent_access)
     end
   end

--- a/lib/ssm_config/ssm_storage/yml.rb
+++ b/lib/ssm_config/ssm_storage/yml.rb
@@ -11,7 +11,11 @@ module SsmConfig
       end
 
       def hash
-        yaml_loaded = YAML.load(ERB.new(File.read((file_path).to_s)).result)
+        yaml_loaded = if Psych::VERSION > '4.0'
+          YAML.safe_load(ERB.new(File.read((file_path).to_s)).result, aliases: true)
+        else
+          YAML.load(ERB.new(File.read((file_path).to_s)).result)
+        end
         (yaml_loaded[Rails.env] || yaml_loaded['any']).try(:with_indifferent_access)
       end
 


### PR DESCRIPTION
Ruby 3.1 uses  Psych 4.0.0 which makes `YAML.load` default to safe mode (https://github.com/ruby/psych/pull/487)

So places where we parse YAML configuration are broken.

Ref - https://github.com/sidekiq/sidekiq/issues/5140