### PR TITLE
Rescue Active Record And Object Constantize

### DIFF
--- a/lib/ssm_config.rb
+++ b/lib/ssm_config.rb
@@ -6,7 +6,7 @@ require 'ssm_config/migration_helper.rb'
 require 'active_support/all'
 
 module SsmConfig
-  VERSION = '1.3.5'.freeze
+  VERSION = '1.3.6'.freeze
   REFRESH_TIME = (30.minutes).freeze
 
   class << self

--- a/lib/ssm_config/ssm_storage/db.rb
+++ b/lib/ssm_config/ssm_storage/db.rb
@@ -11,7 +11,7 @@ module SsmConfig
       def table_exists?
         return active_record_model_exists? if db_connected? && active_record_exists? && constant_exists?
         false
-      rescue ActiveRecord::NoDatabaseError, Mysql2::Error::ConnectionError
+      rescue ActiveRecord::NoDatabaseError, Mysql2::Error::ConnectionError, ActiveRecord::ConnectionNotEstablished
         return false
       end
 
@@ -36,7 +36,7 @@ module SsmConfig
       end
 
       def constant_exists?
-        Object.const_defined? ACTIVE_RECORD_MODEL
+        !ACTIVE_RECORD_MODEL.safe_constantize.nil?
       end
 
       def convert_boolean(value)


### PR DESCRIPTION
Closes https://snapsheettech.atlassian.net/browse/SNAPTX-4461


## For Rake Asset Precompile

- Added handling for ActiveRecord::ConnectionNotEstablished in table_exists? method
- Improved constant_exists? method to use safe_constantize